### PR TITLE
fixed: incorrect metrics generation

### DIFF
--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -561,7 +561,9 @@ function fileDoesNotExistOrIsDirectory(filePath: string): boolean {
 function getTotalActiveFromDeploymentMetrics(metrics: DeploymentMetrics): number {
   let totalActive = 0;
   Object.keys(metrics).forEach((label: string) => {
-    totalActive += metrics[label].active;
+    if(metrics[label].active > 0) {
+      totalActive += metrics[label].active;
+    }
   });
 
   return totalActive;


### PR DESCRIPTION
### **What was happening?**
From codepush server we were receiving negative values which was making our total count as 0. Refer the bug existing at: https://github.com/microsoft/code-push-server/issues/65

The response from server is like this

```json
{
  "4.0.0": {
    "active": -9
  },
  "v1": {
    "active": 2,
    "downloaded": 9,
    "failed": 1,
    "installed": 8
  },
  "v2": {
    "active": 0,
    "downloaded": 6,
    "failed": 0,
    "installed": 6
  },
  "v3": {
    "active": 7,
    "downloaded": 9,
    "failed": 0,
    "installed": 7
  }
}
```

### **What have I done?**

So basically in the cli util, we just add all the `active` of every label. But since there were negative numbers hence it was making it 0. In this PR we will ignore the negative numbers since those numbers is not needed.

### **Why was the negative number is returned by server in the first place?**

That will need further debugging and since the metrics is getting stored in redis cache. Any alteration might make our entire metrics useless. Hence did the change in cli itself